### PR TITLE
Add database configuration and Flyway migration

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>10.21.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>10.21.0</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,2 +1,12 @@
 spring.application.name=backend
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/swappable
+spring.datasource.username=postgres
+spring.datasource.password=Swappable
+
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,42 @@
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL,
+    email VARCHAR(100) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    location VARCHAR(100),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE categories (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50) NOT NULL UNIQUE
+);
+
+CREATE TABLE items (
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL,
+    category_id INT NOT NULL,
+    title VARCHAR(100) NOT NULL,
+    description TEXT,
+    condition VARCHAR(20) NOT NULL,
+    image_url VARCHAR(255),
+    status VARCHAR(20) NOT NULL DEFAULT 'available',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_items_user FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT fk_items_category FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+
+CREATE TABLE swap_requests (
+    id SERIAL PRIMARY KEY,
+    requester_id INT NOT NULL,
+    owner_id INT NOT NULL,
+    requested_item_id INT NOT NULL,
+    offered_item_id INT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    message TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swap_requester FOREIGN KEY (requester_id) REFERENCES users(id),
+    CONSTRAINT fk_swap_owner FOREIGN KEY (owner_id) REFERENCES users(id),
+    CONSTRAINT fk_swap_requested_item FOREIGN KEY (requested_item_id) REFERENCES items(id),
+    CONSTRAINT fk_swap_offered_item FOREIGN KEY (offered_item_id) REFERENCES items(id)
+);

--- a/backend/src/test/java/com/swappable/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/swappable/backend/BackendApplicationTests.java
@@ -2,10 +2,9 @@ package com.swappable.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+
 
 @SpringBootTest
-@ActiveProfiles("test")
 class BackendApplicationTests {
 
 	@Test

--- a/backend/src/test/java/com/swappable/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/swappable/backend/BackendApplicationTests.java
@@ -2,8 +2,10 @@ package com.swappable.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendApplicationTests {
 
 	@Test

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+spring.flyway.enabled=false

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,1 +1,2 @@
 spring.flyway.enabled=false
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,2 +1,0 @@
-spring.flyway.enabled=false
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration


### PR DESCRIPTION
The backend has been connected to a local PostgreSQL database. Flyway was added to pom.xml to manage database migrations. A migration file V1__init_schema.sql was created with all four tables: users, categories, items and swap_requests. The application.properties file was updated with the database connection settings.
To run this locally you need PostgreSQL installed and a database called swappable created in pgAdmin.