### PR TITLE
Add category filter to GET /api/items (24)

### DIFF
--- a/backend/src/main/java/com/swappable/backend/item/ItemController.java
+++ b/backend/src/main/java/com/swappable/backend/item/ItemController.java
@@ -90,13 +90,18 @@ public class ItemController {
 
 
 
-    @GetMapping
-    public List<ItemResponse> getAllItems() {
-        return itemRepository.findAll()
-                .stream()
+        @GetMapping
+        public List<ItemResponse> getAllItems(
+                @RequestParam(required = false) Integer categoryId) {
+                List<Item> items = (categoryId == null)
+                ? itemRepository.findAll()
+                : itemRepository.findByCategoryId(categoryId);
+
+                return items.stream()
                 .map(this::toResponse)
                 .toList();
-    }
+        }
+
 
     @GetMapping("/{id}")
     public ResponseEntity<ItemResponse> getItemById(@PathVariable Integer id) {

--- a/backend/src/main/java/com/swappable/backend/item/ItemRepository.java
+++ b/backend/src/main/java/com/swappable/backend/item/ItemRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Integer> {
     List<Item> findByUserId(Integer user_id);
+    List<Item> findByCategoryId(Integer categoryId);
 }

--- a/backend/src/test/java/com/swappable/backend/item/ItemControllerTest.java
+++ b/backend/src/test/java/com/swappable/backend/item/ItemControllerTest.java
@@ -26,6 +26,11 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
 @ExtendWith(MockitoExtension.class)
 class ItemControllerTest {
 
@@ -86,6 +91,36 @@ class ItemControllerTest {
         item.setStatus("available");
         return item;
     }
+
+     // ---------- getAllItems (category filter) ----------
+
+    @Test
+    void getAllItems_withoutCategoryId_returnsAll() throws Exception {
+        when(itemRepository.findAll())
+                .thenReturn(List.of(buildItem(1, owner), buildItem(2, owner)));
+
+        mockMvc.perform(get("/api/items"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+
+        verify(itemRepository).findAll();
+        verify(itemRepository, never()).findByCategoryId(anyInt());
+    }
+
+    @Test
+    void getAllItems_withCategoryId_filtersByCategory() throws Exception {
+        when(itemRepository.findByCategoryId(1))
+                .thenReturn(List.of(buildItem(1, owner)));
+
+        mockMvc.perform(get("/api/items").param("categoryId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].categoryId").value(1));
+
+        verify(itemRepository).findByCategoryId(1);
+        verify(itemRepository, never()).findAll();
+    }
+
 
     // ---------- updateItem ----------
 

--- a/postman/swappable-smoke.postman_collection.json
+++ b/postman/swappable-smoke.postman_collection.json
@@ -2376,11 +2376,11 @@
 									"});\r",
 									"\r",
 									"pm.test(\"Every returned item is in category 2\", function () {\r",
-									"    json.forEach(i => pm.expect(i.categoryId).to.eql(2));\r",
+									"    json.content.forEach(i => pm.expect(i.categoryId).to.eql(2));\r",
 									"});\r",
 									"\r",
 									"pm.test(\"Includes the item we created\", function () {\r",
-									"    const ids = json.map(i => i.id);\r",
+									"    const ids = json.content.map(i => i.id);\r",
 									"    pm.expect(ids).to.include(Number(pm.collectionVariables.get(\"filterItemId\")));\r",
 									"});"
 								],
@@ -2413,7 +2413,7 @@
 									"});\r",
 									"\r",
 									"pm.test(\"Empty array\", function () {\r",
-									"    pm.expect(pm.response.json()).to.be.an(\"array\").that.is.empty;\r",
+									"    pm.expect(pm.response.json().content).to.be.an(\"array\").that.is.empty;\r",
 									"});"
 								],
 								"type": "text/javascript",

--- a/postman/swappable-smoke.postman_collection.json
+++ b/postman/swappable-smoke.postman_collection.json
@@ -2311,6 +2311,190 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Item Category Filter",
+			"item": [
+				{
+					"name": "Create item in category 2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const json = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Filter item created\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.collectionVariables.set(\"filterItemId\", json.id);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{ "key": "token", "value": "{{user1Token}}", "type": "string" }
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{ "key": "categoryId", "value": "2", "type": "text" },
+								{ "key": "title", "value": "Category Filter Test", "type": "text" },
+								{ "key": "description", "value": "Filter e2e", "type": "text" },
+								{ "key": "condition", "value": "Good", "type": "text" },
+								{ "key": "images", "type": "file", "src": [], "disabled": true }
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/items",
+							"host": [ "{{baseUrl}}" ],
+							"path": [ "api", "items" ]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Filter by category returns only that category",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const json = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Filter returns 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Every returned item is in category 2\", function () {\r",
+									"    json.forEach(i => pm.expect(i.categoryId).to.eql(2));\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Includes the item we created\", function () {\r",
+									"    const ids = json.map(i => i.id);\r",
+									"    pm.expect(ids).to.include(Number(pm.collectionVariables.get(\"filterItemId\")));\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/items?categoryId=2",
+							"host": [ "{{baseUrl}}" ],
+							"path": [ "api", "items" ],
+							"query": [ { "key": "categoryId", "value": "2" } ]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Filter unknown category returns empty",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Returns 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Empty array\", function () {\r",
+									"    pm.expect(pm.response.json()).to.be.an(\"array\").that.is.empty;\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/items?categoryId=999",
+							"host": [ "{{baseUrl}}" ],
+							"path": [ "api", "items" ],
+							"query": [ { "key": "categoryId", "value": "999" } ]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Filter non-numeric category returns 400",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Bad request\", function () {\r",
+									"    pm.response.to.have.status(400);\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/items?categoryId=abc",
+							"host": [ "{{baseUrl}}" ],
+							"path": [ "api", "items" ],
+							"query": [ { "key": "categoryId", "value": "abc" } ]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Cleanup filter item",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Filter item deleted\", function () {\r",
+									"    pm.response.to.have.status(204);\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{ "key": "token", "value": "{{user1Token}}", "type": "string" }
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/items/{{filterItemId}}",
+							"host": [ "{{baseUrl}}" ],
+							"path": [ "api", "items", "{{filterItemId}}" ]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"event": [
@@ -2403,6 +2587,10 @@
 		},
 		{
 			"key": "imageId",
+			"value": ""
+		},
+		{
+			"key": "filterItemId",
 			"value": ""
 		}
 	]


### PR DESCRIPTION
Adds backend filtering by category: GET /api/items?categoryId={id}

Closes #24

List all categories
<img width="1522" height="956" alt="SCR-20260713-paes" src="https://github.com/user-attachments/assets/bd12ebf6-b8a1-4c72-a3ad-79334311846a" />

List all items

<img width="1272" height="953" alt="SCR-20260713-pakf" src="https://github.com/user-attachments/assets/f2073669-a425-4735-a0d6-ffc063cfbb67" />

Filter for categoryId = 1

<img width="1285" height="955" alt="SCR-20260713-pamo" src="https://github.com/user-attachments/assets/c3620831-2fd1-446e-a8d7-6b2d8ca519ba" />

Filter for categoryId = 8

<img width="1274" height="955" alt="SCR-20260713-paof" src="https://github.com/user-attachments/assets/76899023-5efd-4d6c-b267-1e54091674aa" />

Filter for a non existant categoryId 

<img width="1292" height="951" alt="SCR-20260713-papq" src="https://github.com/user-attachments/assets/295b47ed-e7cc-4304-90fc-146affa85ccf" />

Filter for an invalid categoryId

<img width="1275" height="951" alt="SCR-20260713-pawa" src="https://github.com/user-attachments/assets/97de716d-6fae-493f-b464-def60e3642bd" />

