### PR TITLE
Replace SMTP with Brevo API for password reset emails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,8 @@ jobs:
           DB_USER: ${{ secrets.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
-          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
           MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          BREVO_API_KEY: ${{secrets.BREVO_API_KEY}}
 
       - name: Backend wait
         run: |

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -31,9 +31,9 @@ services:
       SPRING_DATASOURCE_USERNAME: ${DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
-      MAIL_USERNAME: ${MAIL_USERNAME}
-      MAIL_PASSWORD: ${MAIL_PASSWORD}
+      BREVO_API_KEY: ${BREVO_API_KEY}
       MAIL_FROM: ${MAIL_FROM}
+      APP_FRONTEND_URL: ${APP_FRONTEND_URL}
     depends_on:
       postgres-db:
         condition: service_healthy

--- a/backend/src/main/java/com/swappable/backend/auth/passwordreset/EmailService.java
+++ b/backend/src/main/java/com/swappable/backend/auth/passwordreset/EmailService.java
@@ -1,47 +1,113 @@
 package com.swappable.backend.auth.passwordreset;
 
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 @Service
 public class EmailService {
 
     private static final Logger log = LoggerFactory.getLogger(EmailService.class);
 
-    private final JavaMailSender mailSender;
+    private final RestClient restClient;
+    private final String brevoApiKey;
+    private final String frontendUrl;
+    private final String fromAddress;
 
-    @Value("${app.frontend.url}")
-    private String frontendUrl;
+    public EmailService(
+            RestClient.Builder restClientBuilder,
+            @Value("${brevo.api.url}") String brevoApiUrl,
+            @Value("${brevo.api.key}") String brevoApiKey,
+            @Value("${app.frontend.url}") String frontendUrl,
+            @Value("${app.mail.from}") String fromAddress) {
 
-    @Value("${app.mail.from}")
-    private String fromAddress;
+        this.restClient = restClientBuilder
+                .baseUrl(brevoApiUrl)
+                .build();
 
-    public EmailService(JavaMailSender mailSender) {
-        this.mailSender = mailSender;
+        this.brevoApiKey = brevoApiKey;
+        this.frontendUrl = frontendUrl;
+        this.fromAddress = fromAddress;
     }
 
     public void sendPasswordResetEmail(String toEmail, String token) {
         log.info("Attempting to send reset email to: {}", toEmail);
+
         String resetLink = frontendUrl + "/reset-password?token=" + token;
 
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom(fromAddress);
-        message.setTo(toEmail);
-        message.setSubject("Reset your Swappable password");
-        message.setText(
+        String textContent =
                 "Hi,\n\n" +
                         "You requested a password reset for your Swappable account.\n\n" +
-                        "Click the link below to reset your password. This link expires in 30 minutes.\n\n" +
+                        "Click the link below to reset your password. " +
+                        "This link expires in 30 minutes.\n\n" +
                         resetLink + "\n\n" +
                         "If you did not request this, you can safely ignore this email.\n\n" +
-                        "The Swappable Team"
+                        "The Swappable Team";
+
+        BrevoEmailRequest request = new BrevoEmailRequest(
+                new BrevoContact("Swappable", fromAddress),
+                List.of(new BrevoContact(null, toEmail)),
+                "Reset your Swappable password",
+                textContent
         );
 
-        mailSender.send(message);
-        log.info("Reset email sent successfully to: {}", toEmail);
+        try {
+            BrevoEmailResponse response = restClient.post()
+                    .uri("/v3/smtp/email")
+                    .header("api-key", brevoApiKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body(BrevoEmailResponse.class);
+
+            if (response == null || response.messageId() == null) {
+                throw new IllegalStateException(
+                        "Brevo returned an empty response or no message ID"
+                );
+            }
+
+            log.info(
+                    "Reset email sent successfully to: {}. Message ID: {}",
+                    toEmail,
+                    response.messageId()
+            );
+
+        } catch (RestClientException exception) {
+            log.error(
+                    "Failed to send reset email to: {}",
+                    toEmail,
+                    exception
+            );
+
+            throw new IllegalStateException(
+                    "Failed to send password reset email through Brevo",
+                    exception
+            );
+        }
+    }
+
+    private record BrevoContact(
+            String name,
+            String email
+    ) {
+    }
+
+    private record BrevoEmailRequest(
+            BrevoContact sender,
+            List<BrevoContact> to,
+            String subject,
+            String textContent
+    ) {
+    }
+
+    private record BrevoEmailResponse(
+            String messageId
+    ) {
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -23,13 +23,9 @@ jwt.expiration=86400000
 server.error.include-message=always
 server.error.include-binding-errors=always
 
-# Email
-spring.mail.host=smtp-relay.brevo.com
-spring.mail.port=587
-spring.mail.username=${MAIL_USERNAME}
-spring.mail.password=${MAIL_PASSWORD}
-spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.starttls.enable=true
+# Brevo transactional email HTTP API
+brevo.api.url=${BREVO_API_URL:https://api.brevo.com}
+brevo.api.key=${BREVO_API_KEY}
 
 # Application
 app.frontend.url=${APP_FRONTEND_URL:http://localhost:5173}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -10,9 +10,7 @@ spring.flyway.enabled=false
 jwt.secret=test-secret-key-for-context-loading-only-not-for-production-use
 jwt.expiration=86400000
 
-spring.mail.host=localhost
-spring.mail.port=3025
-spring.mail.username=test
-spring.mail.password=test
+brevo.api.url=https://api.brevo.com
+brevo.api.key=test-api-key
 app.frontend.url=http://localhost:5173
 app.mail.from=noreply@swappable.com


### PR DESCRIPTION
Remove previous brevo secret vars and add api and brevo url. 

Update CI, docker and application properties. 

Change Email Service to hanfle http requests. Render was blocking smtp requests so this should hopefully work on deployed render free tier.

Passing on local 
<img width="589" height="196" alt="image" src="https://github.com/user-attachments/assets/376dd089-b462-4ee0-b68b-8a3ec534bac0" />
