### PR TITLE
Add public user profile endpoint

### DIFF
--- a/backend/src/main/java/com/swappable/backend/auth/security/SecurityConfig.java
+++ b/backend/src/main/java/com/swappable/backend/auth/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                                 "/api/images/*",
                                 "/api/categories",
                                 "/error").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/users/{id:[0-9]+}").permitAll()
                         .anyRequest().authenticated()
                 ).addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .httpBasic(httpBasic -> httpBasic.disable())

--- a/backend/src/main/java/com/swappable/backend/controller/UserController.java
+++ b/backend/src/main/java/com/swappable/backend/controller/UserController.java
@@ -5,6 +5,11 @@ import com.swappable.backend.auth.dto.UpdateProfileRequest;
 import com.swappable.backend.auth.AuthUtils;
 import com.swappable.backend.user.User;
 import com.swappable.backend.user.UserRepository;
+import com.swappable.backend.user.PublicUserResponse;
+import com.swappable.backend.item.ItemMapper;
+import com.swappable.backend.item.ItemRepository;
+import com.swappable.backend.item.ItemResponse;
+import java.util.List;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
@@ -15,10 +20,20 @@ import jakarta.validation.Valid;
 @RequestMapping("/api/users")
 public class UserController {
 
-    private final UserRepository userRepository;
+    private static final String ITEM_STATUS_AVAILABLE = "available";
 
-    public UserController(UserRepository userRepository) {
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final ItemMapper itemMapper;
+
+    public UserController(
+            UserRepository userRepository,
+            ItemRepository itemRepository,
+            ItemMapper itemMapper
+    ) {
         this.userRepository = userRepository;
+        this.itemRepository = itemRepository;
+        this.itemMapper = itemMapper;
     }
 
     @GetMapping("/me")
@@ -39,6 +54,25 @@ public class UserController {
         if (request.phoneNumber() != null) user.setPhoneNumber(request.phoneNumber());
         userRepository.save(user);
         return toResponse(user);
+    }
+
+    @GetMapping("/{id}")
+    public PublicUserResponse getPublicProfile(@PathVariable Integer id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "User not found"));
+
+        List<ItemResponse> items = itemRepository
+                .findByUserIdAndStatus(user.getId(), ITEM_STATUS_AVAILABLE)
+                .stream()
+                .map(itemMapper::toResponse)
+                .toList();
+
+        return new PublicUserResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getLocation(),
+                items);
     }
 
     private User loadCurrentUser() {

--- a/backend/src/main/java/com/swappable/backend/item/ItemController.java
+++ b/backend/src/main/java/com/swappable/backend/item/ItemController.java
@@ -25,6 +25,7 @@ public class ItemController {
     private final CategoryRepository categoryRepository;
     private final ItemImageRepository itemImageRepository;
     private final ImageService imageService;
+    private final ItemMapper itemMapper;
     private static final List<String> VALID_CONDITIONS = List.of(
             "New",
             "Like New",
@@ -37,38 +38,18 @@ public class ItemController {
             ItemRepository itemRepository,
             CategoryRepository categoryRepository,
             ItemImageRepository itemImageRepository,
-            ImageService imageService
+            ImageService imageService,
+            ItemMapper itemMapper
     ) {
         this.itemRepository = itemRepository;
         this.categoryRepository = categoryRepository;
         this.itemImageRepository = itemImageRepository;
         this.imageService = imageService;
+        this.itemMapper = itemMapper;
     }
 
     private ItemResponse toResponse(Item item) {
-        List<String> imageUrls = itemImageRepository.findIdsByItemId(item.getId())
-                .stream()
-                .map(imageId -> "/api/images/" + imageId)
-                .toList();
-
-        String cover = imageUrls.isEmpty() ? null : imageUrls.get(0);
-
-        return new ItemResponse(
-                item.getId(),
-                item.getTitle(),
-                item.getDescription(),
-                item.getCondition(),
-                cover,
-                item.getStatus(),
-                item.getCategory().getId(),
-                item.getCategory().getName(),
-                item.getUser().getUsername(),
-                item.getUser().getLocation(),
-                item.getUser().getLatitude(),
-                item.getUser().getLongitude(),
-                imageUrls,
-                item.getCreatedAt()
-        );
+        return itemMapper.toResponse(item);
     }
 
     private User getAuthenticatedUser() {

--- a/backend/src/main/java/com/swappable/backend/item/ItemMapper.java
+++ b/backend/src/main/java/com/swappable/backend/item/ItemMapper.java
@@ -1,0 +1,42 @@
+package com.swappable.backend.item;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ItemMapper {
+
+    private final ItemImageRepository itemImageRepository;
+
+    public ItemMapper(ItemImageRepository itemImageRepository) {
+        this.itemImageRepository = itemImageRepository;
+    }
+
+    public ItemResponse toResponse(Item item) {
+        List<String> imageUrls = itemImageRepository.findIdsByItemId(item.getId())
+                .stream()
+                .map(imageId -> "/api/images/" + imageId)
+                .toList();
+
+        String cover = imageUrls.isEmpty() ? null : imageUrls.get(0);
+
+        return new ItemResponse(
+                item.getId(),
+                item.getTitle(),
+                item.getDescription(),
+                item.getCondition(),
+                cover,
+                item.getStatus(),
+                item.getCategory().getId(),
+                item.getCategory().getName(),
+                item.getUser().getId(),
+                item.getUser().getUsername(),
+                item.getUser().getLocation(),
+                item.getUser().getLatitude(),
+                item.getUser().getLongitude(),
+                imageUrls,
+                item.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/swappable/backend/item/ItemRepository.java
+++ b/backend/src/main/java/com/swappable/backend/item/ItemRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Integer> {
     List<Item> findByUserId(Integer user_id);
+
+    List<Item> findByUserIdAndStatus(Integer userId, String status);
 }

--- a/backend/src/main/java/com/swappable/backend/item/ItemResponse.java
+++ b/backend/src/main/java/com/swappable/backend/item/ItemResponse.java
@@ -12,6 +12,7 @@ public record ItemResponse(
         String status,
         Integer categoryId,
         String categoryName,
+        Integer ownerId,
         String ownerUsername,
         String ownerLocation,
         Double ownerLatitude,

--- a/backend/src/main/java/com/swappable/backend/user/PublicUserResponse.java
+++ b/backend/src/main/java/com/swappable/backend/user/PublicUserResponse.java
@@ -1,0 +1,13 @@
+package com.swappable.backend.user;
+
+import com.swappable.backend.item.ItemResponse;
+
+import java.util.List;
+
+public record PublicUserResponse(
+        Integer id,
+        String username,
+        String location,
+        List<ItemResponse> items
+) {
+}

--- a/backend/src/test/java/com/swappable/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/swappable/backend/controller/UserControllerTest.java
@@ -4,6 +4,8 @@ import com.swappable.backend.auth.AuthUtils;
 import com.swappable.backend.auth.dto.UpdateProfileRequest;
 import com.swappable.backend.user.User;
 import com.swappable.backend.user.UserRepository;
+import com.swappable.backend.item.ItemMapper;
+import com.swappable.backend.item.ItemRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,12 +25,14 @@ import static org.mockito.Mockito.*;
 class UserControllerTest {
 
     @Mock private UserRepository userRepository;
+    @Mock private ItemRepository itemRepository;
+    @Mock private ItemMapper itemMapper;
 
     private UserController controller;
 
     @BeforeEach
     void setUp() {
-        controller = new UserController(userRepository);
+        controller = new UserController(userRepository, itemRepository, itemMapper);
     }
 
     private User user(int id, String username, String email, String location, String phoneNumber) {
@@ -121,5 +126,32 @@ class UserControllerTest {
             assertEquals("0879999999", response.phoneNumber());
             verify(userRepository).save(u);
         }
+    }
+
+    // ---------- getPublicProfile (#170) ----------
+
+    @Test
+    void getPublicProfile_returns404_whenUserNotFound() {
+        when(userRepository.findById(999)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.getPublicProfile(999));
+        assertEquals(404, ex.getStatusCode().value());
+    }
+
+    @Test
+    void getPublicProfile_returnsPublicFieldsAndOnlyAvailableItems() {
+        User u = user(1, "owner", "owner@test.com", "Galway", "0851234567");
+        when(userRepository.findById(1)).thenReturn(Optional.of(u));
+        when(itemRepository.findByUserIdAndStatus(1, "available")).thenReturn(List.of());
+
+        var response = controller.getPublicProfile(1);
+
+        assertEquals(1, response.id());
+        assertEquals("owner", response.username());
+        assertEquals("Galway", response.location());
+        assertTrue(response.items().isEmpty());
+        // PublicUserResponse has no email/phone accessor, so PII cannot leak
+        verify(itemRepository).findByUserIdAndStatus(1, "available");
     }
 }

--- a/backend/src/test/java/com/swappable/backend/item/ItemControllerTest.java
+++ b/backend/src/test/java/com/swappable/backend/item/ItemControllerTest.java
@@ -33,6 +33,7 @@ class ItemControllerTest {
     @Mock private CategoryRepository categoryRepository;
     @Mock private ItemImageRepository itemImageRepository;
     @Mock private ImageService imageService;
+    @Mock private ItemMapper itemMapper;
 
     private ItemController itemController;
     private MockMvc mockMvc;
@@ -44,7 +45,7 @@ class ItemControllerTest {
 
     @BeforeEach
     void setUp() {
-        itemController = new ItemController(itemRepository, categoryRepository, itemImageRepository, imageService);
+        itemController = new ItemController(itemRepository, categoryRepository, itemImageRepository, imageService, itemMapper);
         mockMvc = MockMvcBuilders.standaloneSetup(itemController).build();
 
         owner = new User();


### PR DESCRIPTION
Adds a public GET /api/users/{id} endpoint that returns a user's username, location and their available items. No email or phone number.

Also adds ownerId to ItemResponse so item cards can link to the profile page.

Closes #170. Unblocks #76.

Test:

Public endpoint:

<img width="1039" height="764" alt="SCR-20260721-iant-2" src="https://github.com/user-attachments/assets/267b2cfc-5293-43b4-852a-ed6c3aab143c" />

/me requires auth and is not public

<img width="1039" height="764" alt="SCR-20260721-iapo" src="https://github.com/user-attachments/assets/eeece2eb-6100-41e4-a00a-9f96313c82f5" />

