### PR TITLE
Add public /users/:id profile page with card/list toggle and owner links

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import EditItemPage from './pages/EditItemPage.jsx';
 import MyItemsPage from './pages/MyItemsPage.jsx';
 import ItemDetailPage from './pages/ItemDetailPage.jsx';
 import BrowseItemsPage from './pages/BrowseItemsPage.jsx';
+import UserProfilePage from './pages/UserProfilePage.jsx';
 import HowItWorksPage from './pages/HowItWorksPage.jsx';
 import NotFoundPage from './pages/NotFoundPage.jsx';
 import ForgotPasswordPage from './pages/ForgotPasswordPage.jsx'
@@ -32,6 +33,7 @@ function App() {
           <Route path="/items/edit/:id" element={<EditItemPage />} />
           <Route path="/my-items" element={<MyItemsPage />} />
           <Route path="/items/:id" element={<ItemDetailPage />} />
+          <Route path="/users/:id" element={<UserProfilePage />} />
           <Route path="*" element={<NotFoundPage />} />
           <Route path="/forgot-password" element={<ForgotPasswordPage />} />
           <Route path="/reset-password" element={<ResetPasswordPage />} />

--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -1,27 +1,33 @@
 // src/api/users.js
 // Profile read/update, matching the fetch + JWT pattern in swapRequests.js
 
-import { API_BASE_URL } from './config.js'
+import { API_BASE_URL } from './config.js';
 
-const BASE = API_BASE_URL
+const BASE = API_BASE_URL;
 
 function authHeaders() {
-  const token = localStorage.getItem('token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
+  const token = localStorage.getItem('token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
 async function handle(res) {
-  if (res.status === 401) throw new Error('unauthenticated')
+  if (res.status === 401) throw new Error('unauthenticated');
   if (!res.ok) {
-    let msg = 'Request failed'
-    try { msg = (await res.json()).error || msg } catch {}
-    throw new Error(msg)
+    let msg = 'Request failed';
+    try {
+      msg = (await res.json()).error || msg;
+    } catch {}
+    throw new Error(msg);
   }
-  return res.json()
+  return res.json();
 }
 
 export function getMyProfile() {
-  return fetch(`${BASE}/users/me`, { headers: authHeaders() }).then(handle)
+  return fetch(`${BASE}/users/me`, { headers: authHeaders() }).then(handle);
+}
+
+export function getPublicProfile(id) {
+  return fetch(`${BASE}/users/${id}`).then(handle);
 }
 
 export function updateMyProfile(data) {
@@ -29,5 +35,5 @@ export function updateMyProfile(data) {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(data),
-  }).then(handle)
+  }).then(handle);
 }

--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -10,6 +10,7 @@ export default function ItemCard({ item }) {
     category,
     condition,
     owner,
+    ownerId,
     location,
     imageUrl,
   } = item;
@@ -32,7 +33,9 @@ export default function ItemCard({ item }) {
   // placeholders: the click targets exist now so they can be wired up later.
   const handleCategoryClick = () => {}; // TODO: filter items by this category
   const handleLocationClick = () => {}; // TODO: filter items by this location
-  const handleOwnerClick = () => {}; // TODO: open this owner's public listings
+  const handleOwnerClick = () => {
+    if (ownerId) navigate(`/users/${ownerId}`);
+  };
   return (
     <div className="card h-100">
       {imageUrl ? (

--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -1,12 +1,6 @@
 import { useNavigate } from 'react-router-dom';
-
-const CONDITION_COLORS = {
-  'Like New': 'success',
-  Good: 'primary',
-  Fair: 'warning',
-  Poor: 'danger',
-};
-import {resolveImageUrl} from "../api/config.js";
+import { resolveImageUrl } from '../api/config.js';
+import { CONDITION_COLORS } from '../lib/constants.js';
 
 export default function ItemCard({ item }) {
   const {

--- a/frontend/src/components/ItemList.jsx
+++ b/frontend/src/components/ItemList.jsx
@@ -1,0 +1,57 @@
+import { useNavigate } from 'react-router-dom'
+import { CONDITION_COLORS } from '../lib/constants.js'
+
+// vertical list view of items, an alternative to the card grid
+export default function ItemList({ items }) {
+  const navigate = useNavigate()
+
+  if (items.length === 0) {
+    return (
+      <div className="text-center py-5">
+        <i className="bi bi-search text-muted d-block mb-3" style={{ fontSize: '2.5rem' }}></i>
+        <h5 className="fw-semibold">No items found</h5>
+        <p className="text-muted mb-0">Try adjusting your search or filters.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="list-group shadow-sm">
+      {items.map((item) => {
+        const badgeColor = CONDITION_COLORS[item.condition] ?? 'secondary'
+        return (
+          <div
+            key={item.id}
+            className="list-group-item list-group-item-action d-flex align-items-center gap-3 clickable"
+            role="button"
+            onClick={() => navigate(`/items/${item.id}`)}
+          >
+            {item.imageUrl ? (
+              <img
+                src={item.imageUrl}
+                alt={item.title}
+                className="rounded flex-shrink-0"
+                style={{ width: 64, height: 64, objectFit: 'cover' }}
+              />
+            ) : (
+              <div
+                className="bg-light d-flex align-items-center justify-content-center rounded flex-shrink-0"
+                style={{ width: 64, height: 64 }}
+              >
+                <i className="bi bi-image text-muted" style={{ fontSize: '1.5rem' }}></i>
+              </div>
+            )}
+            <div className="flex-grow-1" style={{ minWidth: 0 }}>
+              <div className="d-flex justify-content-between align-items-start">
+                <h6 className="fw-semibold mb-1">{item.title}</h6>
+                <span className={`badge bg-${badgeColor} ms-2 text-nowrap`}>{item.condition}</span>
+              </div>
+              <p className="text-muted small mb-1 text-truncate">{item.description}</p>
+              <span className="badge bg-light text-secondary border">{item.category}</span>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -23,3 +23,11 @@ export const DEFAULT_CATEGORY_ICON = 'bi-box';
 
 // condition options describe the physical state of the item
 export const CONDITIONS = ['New', 'Like New', 'Good', 'Fair', 'Poor'];
+
+// bootstrap badge color for each condition
+export const CONDITION_COLORS = {
+  'Like New': 'success',
+  Good: 'primary',
+  Fair: 'warning',
+  Poor: 'danger',
+};

--- a/frontend/src/pages/BrowseItemsPage.jsx
+++ b/frontend/src/pages/BrowseItemsPage.jsx
@@ -23,6 +23,7 @@ function toCardItem(item) {
     category: item.categoryName,
     condition: item.condition,
     owner: item.ownerUsername,
+    ownerId: item.ownerId,
     location: item.ownerLocation,
     lat: item.ownerLatitude,
     lng: item.ownerLongitude,

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -15,6 +15,7 @@ function toCardItem(item) {
     category: item.categoryName,
     condition: item.condition,
     owner: item.ownerUsername,
+    ownerId: item.ownerId,
     location: item.ownerLocation,
     imageUrl: item.imageUrl,
   };

--- a/frontend/src/pages/ItemDetailPage.jsx
+++ b/frontend/src/pages/ItemDetailPage.jsx
@@ -200,7 +200,13 @@ function ItemDetailPage() {
               <div className="border-top pt-3 mb-4">
                 <p className="mb-1">
                   <span className="fw-semibold">Listed by: </span>
-                  {item.ownerUsername}
+                  <span
+                    className="clickable"
+                    role="button"
+                    onClick={() => item.ownerId && navigate(`/users/${item.ownerId}`)}
+                  >
+                    {item.ownerUsername}
+                  </span>
                 </p>
                 <p className="mb-1">
                   <span className="fw-semibold">Location: </span>

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import ItemGrid from '../components/ItemGrid.jsx'
+import ItemList from '../components/ItemList.jsx'
+import { getPublicProfile } from '../api/users.js'
+import { BRAND_COLOR } from '../lib/constants.js'
+
+// map a backend item (ItemResponse) onto the shape ItemCard expects
+function toCardItem(item) {
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description,
+    category: item.categoryName,
+    condition: item.condition,
+    owner: item.ownerUsername,
+    ownerId: item.ownerId,
+    location: item.ownerLocation,
+    imageUrl: item.imageUrl,
+  }
+}
+
+// public read-only profile: a member and the items they have listed
+export default function UserProfilePage() {
+  const { id } = useParams()
+  const [profile, setProfile] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [viewMode, setViewMode] = useState('cards')
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      setLoading(true)
+      setError('')
+      try {
+        const data = await getPublicProfile(id)
+        setProfile(data)
+      } catch {
+        setError('Could not load this member.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadProfile()
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="container pt-2 pb-5 text-center py-5">
+        <div className="spinner-border" style={{ color: BRAND_COLOR }} role="status">
+          <span className="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="container pt-2 pb-5">
+        <div className="alert alert-warning">{error}</div>
+      </div>
+    )
+  }
+
+  const items = (profile.items ?? []).map(toCardItem)
+
+  return (
+    <div className="container pt-2 pb-5">
+      {/* member header */}
+      <div className="card shadow-sm mb-4">
+        <div className="card-body p-4 d-flex align-items-center">
+          <div
+            className="rounded-circle bg-light d-flex align-items-center justify-content-center me-3 flex-shrink-0"
+            style={{ width: 64, height: 64 }}
+          >
+            <i className="bi bi-person" style={{ fontSize: '2rem', color: BRAND_COLOR }}></i>
+          </div>
+          <div>
+            <h3 className="fw-semibold mb-1">{profile.username}</h3>
+            {profile.location && (
+              <p className="text-muted mb-0">
+                <i className="bi bi-geo-alt me-1"></i>
+                {profile.location}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* member's listed items */}
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h4 className="fw-bold mb-0">
+          Listings <span className="text-muted fw-normal">({items.length})</span>
+        </h4>
+        <div className="btn-group" role="group" aria-label="View mode">
+          <button
+            type="button"
+            className={`btn btn-sm ${viewMode === 'cards' ? 'btn-primary' : 'btn-outline-primary'}`}
+            onClick={() => setViewMode('cards')}
+            aria-pressed={viewMode === 'cards'}
+          >
+            <i className="bi bi-grid"></i>
+          </button>
+          <button
+            type="button"
+            className={`btn btn-sm ${viewMode === 'list' ? 'btn-primary' : 'btn-outline-primary'}`}
+            onClick={() => setViewMode('list')}
+            aria-pressed={viewMode === 'list'}
+          >
+            <i className="bi bi-list-ul"></i>
+          </button>
+        </div>
+      </div>
+      {viewMode === 'cards' ? <ItemGrid items={items} /> : <ItemList items={items} />}
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a public user profile page at /users/:id (member header + their available listings), a cards/list view toggle, and owner-name links from item cards and the item detail page.

Backend endpoint tracked in #188.

Closes #76 