### PR TITLE
Add delete swap request endpoint

### DIFF
--- a/backend/src/main/java/com/swappable/backend/swaprequest/SwapRequestController.java
+++ b/backend/src/main/java/com/swappable/backend/swaprequest/SwapRequestController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 

--- a/backend/src/main/java/com/swappable/backend/swaprequest/SwapRequestController.java
+++ b/backend/src/main/java/com/swappable/backend/swaprequest/SwapRequestController.java
@@ -165,6 +165,35 @@ public class SwapRequestController {
 
         return toResponse(savedSwapRequest, owner.getId());
     }
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> cancelSwapRequest(@PathVariable Integer id) {
+        User currentUser = AuthUtils.getAuthenticatedUser();
+
+        SwapRequest swapRequest = swapRequestRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Swap request not found"
+                ));
+
+        // Ensuring that only the user who created (requested) the swap can cancel/delete it
+        if (!swapRequest.getRequester().getId().equals(currentUser.getId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "You can only cancel your own swap requests"
+            );
+        }
+
+
+        if (!swapRequest.getStatus().equals(STATUS_PENDING)) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Can only delete pending swap requests"
+            );
+        }
+
+        swapRequestRepository.delete(swapRequest);
+        return ResponseEntity.noContent().build();
+    }
 
     @PostMapping("/{id}/decline")
     public SwapRequestResponse declineSwapRequest(@PathVariable Integer id) {


### PR DESCRIPTION
<img width="1068" height="372" alt="Screenshot 2026-07-21 150343" src="https://github.com/user-attachments/assets/8aaceaea-6ae6-402d-b34c-e644e81b988d" />

Hi, 
This PR deals with delete/cancel swap requests. Implemented authentication checks so that only the person who created the swap request can delete it. Added validation so that swap requests may only be deleted when they are in a pending state