### PR TITLE
Track swap requests and fix database migration config

### DIFF
--- a/backend/src/main/java/com/swappable/backend/BackendApplication.java
+++ b/backend/src/main/java/com/swappable/backend/BackendApplication.java
@@ -2,14 +2,23 @@ package com.swappable.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
 public class BackendApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BackendApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
 
+    @Bean
+    public FlywayMigrationStrategy repairAndMigrateStrategy() {
+        return flyway -> {
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
 }

--- a/backend/src/main/java/com/swappable/backend/swaprequest/SwapRequestController.java
+++ b/backend/src/main/java/com/swappable/backend/swaprequest/SwapRequestController.java
@@ -123,7 +123,28 @@ public class SwapRequestController {
                 .map(swapRequest -> toResponse(swapRequest, owner.getId()))
                 .toList();
     }
+    @GetMapping("/{id}")
+    public SwapRequestResponse getSwapRequestById(@PathVariable Integer id) {
+        User currentUser = AuthUtils.getAuthenticatedUser();
 
+        SwapRequest swapRequest = swapRequestRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Swap request not found"
+                ));
+
+        boolean isOwner = swapRequest.getOwner().getId().equals(currentUser.getId());
+        boolean isRequester = swapRequest.getRequester().getId().equals(currentUser.getId());
+
+        if (!isOwner && !isRequester) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "You are not authorized to view this swap request"
+            );
+        }
+
+        return toResponse(swapRequest, currentUser.getId());
+    }
     @GetMapping("/sent")
     public List<SwapRequestResponse> getOutgoingSwapRequests() {
         User requester = AuthUtils.getAuthenticatedUser();


### PR DESCRIPTION
<img width="1030" height="413" alt="Screenshot 2026-07-21 154822" src="https://github.com/user-attachments/assets/83dd9b21-9f76-42d1-8027-50da2092b051" />

Hi, 
This PR handles swap tracking. It uses HTTP get requests to retrieve a swap request by its ID. 
It uses authentication and fetching. It does this by grabbing a logged in user, looks up swap request by ID. If the swap does not exist, then it automatically throws a 404 not found error. 
It uses authorization security checks by verifying that the logged in user is the owner of the item/person who made the request. 
It uses access control. If that current user is neither of those two people then it blocks them from viewing it. (line 139) gives an unauthorized response. 
