### PR TITLE
Paginate public user profile listings

### DIFF
--- a/backend/src/main/java/com/swappable/backend/controller/UserController.java
+++ b/backend/src/main/java/com/swappable/backend/controller/UserController.java
@@ -6,10 +6,14 @@ import com.swappable.backend.auth.AuthUtils;
 import com.swappable.backend.user.User;
 import com.swappable.backend.user.UserRepository;
 import com.swappable.backend.user.PublicUserResponse;
+import com.swappable.backend.common.PagedResponse;
 import com.swappable.backend.item.ItemMapper;
 import com.swappable.backend.item.ItemRepository;
 import com.swappable.backend.item.ItemResponse;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
@@ -57,22 +61,23 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
-    public PublicUserResponse getPublicProfile(@PathVariable Integer id) {
+    public PublicUserResponse getPublicProfile(
+            @PathVariable Integer id,
+            @PageableDefault(size = 18, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "User not found"));
 
-        List<ItemResponse> items = itemRepository
-                .findByUserIdAndStatus(user.getId(), ITEM_STATUS_AVAILABLE)
-                .stream()
-                .map(itemMapper::toResponse)
-                .toList();
+        Page<ItemResponse> items = itemRepository
+                .findByUserIdAndStatus(user.getId(), ITEM_STATUS_AVAILABLE, pageable)
+                .map(itemMapper::toResponse);
 
         return new PublicUserResponse(
                 user.getId(),
                 user.getUsername(),
                 user.getLocation(),
-                items);
+                PagedResponse.from(items));
     }
 
     private User loadCurrentUser() {

--- a/backend/src/main/java/com/swappable/backend/controller/UserController.java
+++ b/backend/src/main/java/com/swappable/backend/controller/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
     @GetMapping("/{id}")
     public PublicUserResponse getPublicProfile(
             @PathVariable Integer id,
-            @PageableDefault(size = 18, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(

--- a/backend/src/main/java/com/swappable/backend/item/ItemRepository.java
+++ b/backend/src/main/java/com/swappable/backend/item/ItemRepository.java
@@ -18,6 +18,8 @@ public interface ItemRepository extends JpaRepository<Item, Integer> {
 
     List<Item> findByUserIdAndStatus(Integer userId, String status);
 
+    Page<Item> findByUserIdAndStatus(Integer userId, String status, Pageable pageable);
+
     Page<Item> findByCategoryId(Integer categoryId, Pageable pageable);
 
     Page<Item> findByArchivedFalse(Pageable pageable);

--- a/backend/src/main/java/com/swappable/backend/user/PublicUserResponse.java
+++ b/backend/src/main/java/com/swappable/backend/user/PublicUserResponse.java
@@ -1,13 +1,12 @@
 package com.swappable.backend.user;
 
+import com.swappable.backend.common.PagedResponse;
 import com.swappable.backend.item.ItemResponse;
-
-import java.util.List;
 
 public record PublicUserResponse(
         Integer id,
         String username,
         String location,
-        List<ItemResponse> items
+        PagedResponse<ItemResponse> items
 ) {
 }

--- a/backend/src/test/java/com/swappable/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/swappable/backend/controller/UserControllerTest.java
@@ -4,18 +4,25 @@ import com.swappable.backend.auth.AuthUtils;
 import com.swappable.backend.auth.dto.UpdateProfileRequest;
 import com.swappable.backend.user.User;
 import com.swappable.backend.user.UserRepository;
+import com.swappable.backend.item.Item;
 import com.swappable.backend.item.ItemMapper;
 import com.swappable.backend.item.ItemRepository;
+import com.swappable.backend.item.ItemResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -135,23 +142,53 @@ class UserControllerTest {
         when(userRepository.findById(999)).thenReturn(Optional.empty());
 
         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                () -> controller.getPublicProfile(999));
+                () -> controller.getPublicProfile(999, Pageable.unpaged()));
         assertEquals(404, ex.getStatusCode().value());
     }
 
     @Test
     void getPublicProfile_returnsPublicFieldsAndOnlyAvailableItems() {
         User u = user(1, "owner", "owner@test.com", "Galway", "0851234567");
+        Pageable pageable = PageRequest.of(0, 18);
         when(userRepository.findById(1)).thenReturn(Optional.of(u));
-        when(itemRepository.findByUserIdAndStatus(1, "available")).thenReturn(List.of());
+        when(itemRepository.findByUserIdAndStatus(1, "available", pageable))
+                .thenReturn(Page.empty(pageable));
 
-        var response = controller.getPublicProfile(1);
+        var response = controller.getPublicProfile(1, pageable);
 
         assertEquals(1, response.id());
         assertEquals("owner", response.username());
         assertEquals("Galway", response.location());
-        assertTrue(response.items().isEmpty());
+        assertTrue(response.items().content().isEmpty());
+        assertEquals(0, response.items().totalElements());
         // PublicUserResponse has no email/phone accessor, so PII cannot leak
-        verify(itemRepository).findByUserIdAndStatus(1, "available");
+        verify(itemRepository).findByUserIdAndStatus(1, "available", pageable);
+    }
+
+    @Test
+    void getPublicProfile_mapsItemsAndPagedMetadata() {
+        User u = user(1, "owner", "owner@test.com", "Galway", "0851234567");
+        Pageable pageable = PageRequest.of(0, 18);
+        Item first = new Item();
+        Item second = new Item();
+        ItemResponse firstResponse = itemResponse(10, "First");
+        ItemResponse secondResponse = itemResponse(11, "Second");
+
+        when(userRepository.findById(1)).thenReturn(Optional.of(u));
+        when(itemRepository.findByUserIdAndStatus(1, "available", pageable))
+                .thenReturn(new PageImpl<>(List.of(first, second), pageable, 2));
+        when(itemMapper.toResponse(first)).thenReturn(firstResponse);
+        when(itemMapper.toResponse(second)).thenReturn(secondResponse);
+
+        var response = controller.getPublicProfile(1, pageable);
+
+        assertEquals(List.of(firstResponse, secondResponse), response.items().content());
+        assertEquals(2, response.items().totalElements());
+        assertEquals(1, response.items().totalPages());
+    }
+
+    private ItemResponse itemResponse(Integer id, String title) {
+        return new ItemResponse(id, title, "desc", "Good", null, "available",
+                1, "Books", 1, "owner", null, null, null, List.of(), null);
     }
 }

--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -26,8 +26,8 @@ export function getMyProfile() {
   return fetch(`${BASE}/users/me`, { headers: authHeaders() }).then(handle);
 }
 
-export function getPublicProfile(id) {
-  return fetch(`${BASE}/users/${id}`).then(handle);
+export function getPublicProfile(id, page = 0, size = 18) {
+  return fetch(`${BASE}/users/${id}?page=${page}&size=${size}`).then(handle);
 }
 
 export function updateMyProfile(data) {

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -27,9 +27,15 @@ export default function UserProfilePage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [viewMode, setViewMode] = useState('cards')
+  const [page, setPage] = useState(0)
 
   // public profiles are keyed by numeric id; "me" is not a public profile
   const isNumericId = /^\d+$/.test(id)
+
+  // start from the first page when viewing a different member
+  useEffect(() => {
+    setPage(0)
+  }, [id])
 
   useEffect(() => {
     if (!isNumericId) return
@@ -37,7 +43,7 @@ export default function UserProfilePage() {
       setLoading(true)
       setError('')
       try {
-        const data = await getPublicProfile(id)
+        const data = await getPublicProfile(id, page)
         setProfile(data)
       } catch {
         setError('Could not load this member.')
@@ -46,7 +52,7 @@ export default function UserProfilePage() {
       }
     }
     loadProfile()
-  }, [id, isNumericId])
+  }, [id, isNumericId, page])
 
   // /users/me should go to your own profile, or login when logged out
   if (id === 'me') {
@@ -77,7 +83,10 @@ export default function UserProfilePage() {
     )
   }
 
-  const items = (profile.items ?? []).map(toCardItem)
+  const paged = profile.items ?? {}
+  const items = (paged.content ?? []).map(toCardItem)
+  const totalPages = paged.totalPages ?? 0
+  const totalElements = paged.totalElements ?? items.length
 
   return (
     <div className="container pt-2 pb-5">
@@ -105,7 +114,7 @@ export default function UserProfilePage() {
       {/* member's listed items */}
       <div className="d-flex justify-content-between align-items-center mb-3">
         <h4 className="fw-bold mb-0">
-          Listings <span className="text-muted fw-normal">({items.length})</span>
+          Listings <span className="text-muted fw-normal">({totalElements})</span>
         </h4>
         <div className="btn-group" role="group" aria-label="View mode">
           <button
@@ -127,6 +136,26 @@ export default function UserProfilePage() {
         </div>
       </div>
       {viewMode === 'cards' ? <ItemGrid items={items} /> : <ItemList items={items} />}
+
+      {totalPages > 1 && (
+        <div className="d-flex justify-content-center align-items-center gap-3 mt-4 mb-4">
+          <button
+            className="btn btn-outline-secondary btn-sm"
+            onClick={() => setPage((p) => Math.max(p - 1, 0))}
+            disabled={page === 0}
+          >
+            Previous
+          </button>
+          <span className="text-muted small">Page {page + 1} of {totalPages}</span>
+          <button
+            className="btn btn-outline-secondary btn-sm"
+            onClick={() => setPage((p) => Math.min(p + 1, totalPages - 1))}
+            disabled={page + 1 >= totalPages}
+          >
+            Next
+          </button>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
- Public /users/{id} listings are paginated, consistent with My Items and Swap Requests
- Backend returns items as a PagedResponse (20 per page)
- Previous/Next controls on both card and list views
- Listings count reflects total, not just the current page

Closes #190.