### PR TITLE
Deduplicate toCardItem mapper

### DIFF
--- a/frontend/src/api/items.js
+++ b/frontend/src/api/items.js
@@ -2,6 +2,23 @@ import { API_BASE_URL } from './config.js'
 
 const BASE = API_BASE_URL
 
+// map a backend item (ItemResponse) onto the shape ItemCard expects
+export function toCardItem(item) {
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description,
+    category: item.categoryName,
+    condition: item.condition,
+    owner: item.ownerUsername,
+    ownerId: item.ownerId,
+    location: item.ownerLocation,
+    lat: item.ownerLatitude,
+    lng: item.ownerLongitude,
+    imageUrl: item.imageUrl,
+  }
+}
+
 function authHeaders() {
   const token = localStorage.getItem('token');
   return token ? { Authorization: `Bearer ${token}` } : {};

--- a/frontend/src/pages/BrowseItemsPage.jsx
+++ b/frontend/src/pages/BrowseItemsPage.jsx
@@ -5,6 +5,7 @@ import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import { API_BASE_URL, resolveImageUrl } from '../api/config.js'
+import { toCardItem } from '../api/items.js'
 import { CONDITIONS } from '../lib/constants.js'
 
 // fix leaflet's default marker icon not loading in vite
@@ -14,23 +15,6 @@ L.Icon.Default.mergeOptions({
   iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
   shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
 })
-
-// map a backend item (ItemResponse) onto the shape ItemCard expects
-function toCardItem(item) {
-  return {
-    id: item.id,
-    title: item.title,
-    description: item.description,
-    category: item.categoryName,
-    condition: item.condition,
-    owner: item.ownerUsername,
-    ownerId: item.ownerId,
-    location: item.ownerLocation,
-    lat: item.ownerLatitude,
-    lng: item.ownerLongitude,
-    imageUrl: item.imageUrl,
-  }
-}
 
 // calculates distance in km between two coordinates
 function haversineDistance(lat1, lng1, lat2, lng2) {

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -5,21 +5,7 @@ import CategoryCard from '../components/CategoryCard.jsx';
 import HowItWorksSection from '../components/HowItWorksSection.jsx';
 import { CATEGORY_ICONS, DEFAULT_CATEGORY_ICON } from '../lib/constants.js';
 import {API_BASE_URL} from "../api/config.js";
-
-// map a backend item (ItemResponse) onto the shape ItemCard expects
-function toCardItem(item) {
-  return {
-    id: item.id,
-    title: item.title,
-    description: item.description,
-    category: item.categoryName,
-    condition: item.condition,
-    owner: item.ownerUsername,
-    ownerId: item.ownerId,
-    location: item.ownerLocation,
-    imageUrl: item.imageUrl,
-  };
-}
+import { toCardItem } from '../api/items.js';
 
 export default function HomePage() {
   const [featuredItems, setFeaturedItems] = useState([]);

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -3,22 +3,8 @@ import { useParams, Navigate } from 'react-router-dom'
 import ItemGrid from '../components/ItemGrid.jsx'
 import ItemList from '../components/ItemList.jsx'
 import { getPublicProfile } from '../api/users.js'
+import { toCardItem } from '../api/items.js'
 import { BRAND_COLOR } from '../lib/constants.js'
-
-// map a backend item (ItemResponse) onto the shape ItemCard expects
-function toCardItem(item) {
-  return {
-    id: item.id,
-    title: item.title,
-    description: item.description,
-    category: item.categoryName,
-    condition: item.condition,
-    owner: item.ownerUsername,
-    ownerId: item.ownerId,
-    location: item.ownerLocation,
-    imageUrl: item.imageUrl,
-  }
-}
 
 // public read-only profile: a member and the items they have listed
 export default function UserProfilePage() {


### PR DESCRIPTION
- Single toCardItem lives in src/api/items.js
- Home, Browse, and User Profile pages import it instead of local copies
- Unified mapper includes all fields (ownerId, lat, lng) so cards behave the same everywhere

Closes #191.