### PR TITLE
Add cancel swap request functionality

### DIFF
--- a/frontend/src/api/swapRequests.js
+++ b/frontend/src/api/swapRequests.js
@@ -51,7 +51,7 @@ export function confirmSwapRequest(id) {
 }
 
 export function cancelSwapRequest(id) {
-  return fetch(`${BASE}/swap-requests/${id}/cancel`, { method: 'PUT', headers: authHeaders() }).then(handle)
+  return fetch(`${BASE}/swap-requests/${id}`, { method: 'DELETE', headers: authHeaders() }).then(handle)
 }
 
 // Used by ItemDetailPage to fill the "what do you offer" dropdown.

--- a/frontend/src/pages/SwapRequestsPage.jsx
+++ b/frontend/src/pages/SwapRequestsPage.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react'
 import { BRAND_COLOR } from '../lib/constants'
 import {
-  getReceivedSwapRequests, getSentSwapRequests,
-
-  acceptSwapRequest, declineSwapRequest, confirmSwapRequest,
-
+  getReceivedSwapRequests,
+  getSentSwapRequests,
+  acceptSwapRequest,
+  declineSwapRequest,
+  confirmSwapRequest,
+  cancelSwapRequest
 } from '../api/swapRequests'
 
 // backend sends lowercase status (pending/accepted/declined/cancelled/completed)
@@ -52,6 +54,9 @@ function SwapRequestsPage() {
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+
+  const [showCancelModal, setShowCancelModal] = useState(false)
+  const [requestToCancel, setRequestToCancel] = useState(null)
 
   // independent pagination state per tab
   const [receivedPage, setReceivedPage] = useState(0)
@@ -103,6 +108,26 @@ function SwapRequestsPage() {
       catch (err) { setError('Could not confirm the swap. Please try again.') }
     }
 
+  const handleCancel = async (id) => {
+    try {
+      setError('')
+
+      await cancelSwapRequest(id)
+
+      setShowCancelModal(false)
+      setRequestToCancel(null)
+
+      await load()
+
+    } catch (err) {
+      if (err.message === 'unauthenticated') {
+        setError('You must be logged in to cancel a request.')
+        return
+      }
+
+      setError(err.message || 'Could not cancel the request. Please try again.')
+    }
+  }
 
   // pick badge colour based on status
   const statusBadge = (status) => {
@@ -253,12 +278,24 @@ function SwapRequestsPage() {
                       <p className="mb-1 text-muted small">
                         You offer: <strong>{request.offeredItemTitle}</strong>
                       </p>
-                      <p className="mb-0 text-muted small">
+                      <p className="mb-3 text-muted small">
                         You want: <strong>{request.requestedItemTitle}</strong>
                       </p>
 
+                      {norm(request.status) === 'pending' && (
+                          <button
+                              className="btn btn-sm btn-outline-danger"
+                              onClick={() => {
+                                setRequestToCancel(request.id)
+                                setShowCancelModal(true)
+                              }}
+                          >
+                            Cancel Request
+                          </button>
+                      )}
+
                       {norm(request.status) === 'accepted' && (
-                        <ConfirmSwap mine={request.requesterConfirmed} onConfirm={() => handleConfirm(request.id)} />
+                          <ConfirmSwap mine={request.requesterConfirmed} onConfirm={() => handleConfirm(request.id)} />
                       )}
 
                       {norm(request.status) === 'completed' && (
@@ -306,6 +343,76 @@ function SwapRequestsPage() {
           </div>
         </div>
       </div>
+
+      {showCancelModal && (
+          <>
+            <div
+                className="modal fade show d-block"
+                tabIndex="-1"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="cancelSwapModalTitle"
+            >
+              <div className="modal-dialog modal-dialog-centered">
+                <div className="modal-content">
+                  <div className="modal-header">
+                    <h5
+                        className="modal-title"
+                        id="cancelSwapModalTitle"
+                    >
+                      Cancel Swap Request
+                    </h5>
+
+                    <button
+                        type="button"
+                        className="btn-close"
+                        aria-label="Close"
+                        onClick={() => {
+                          setShowCancelModal(false)
+                          setRequestToCancel(null)
+                        }}
+                    />
+                  </div>
+
+                  <div className="modal-body">
+                    <p className="mb-2">
+                      Are you sure you want to cancel this swap request?
+                    </p>
+
+                    <p className="text-muted mb-0">
+                      This action cannot be undone.
+                    </p>
+                  </div>
+
+                  <div className="modal-footer">
+                    <button
+                        type="button"
+                        className="btn btn-outline-secondary"
+                        onClick={() => {
+                          setShowCancelModal(false)
+                          setRequestToCancel(null)
+                        }}
+                    >
+                      Keep Request
+                    </button>
+
+                    <button
+                        type="button"
+                        className="btn btn-danger"
+                        onClick={() => handleCancel(requestToCancel)}
+                        disabled={requestToCancel === null}
+                    >
+                      Cancel Request
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="modal-backdrop fade show" />
+          </>
+      )}
+
     </div>
   )
 }


### PR DESCRIPTION
This PR implements:
Links with newly added Delete endpoint. 
A confirmation dialog that matches the rest of your application.
A clear title.
An explanation that the action cannot be undone.
Two obvious actions ("Keep Request" and "Cancel Request").
A close (×) button.
A dark backdrop.

Updates FE  API from PUT to DELETE. 

 
<img width="1122" height="503" alt="image" src="https://github.com/user-attachments/assets/b55a02e1-4231-4e18-a461-17319144a414" />


<img width="945" height="324" alt="image" src="https://github.com/user-attachments/assets/a7b1684b-5708-4cf8-9a3f-81cf685a2c14" />


Existing behaviour unaffected:

<img width="960" height="351" alt="image" src="https://github.com/user-attachments/assets/2a9567e4-ed55-470e-b2dc-597c7897bddc" />

<img width="918" height="358" alt="image" src="https://github.com/user-attachments/assets/3bcf450d-a1bc-449a-85b7-0ff1a0350ea9" />
